### PR TITLE
Handle case where service address is empty coming from health endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -192,14 +192,22 @@ func (c *Client) PickServiceMultipleTags(service string, tags []string, passingO
 		return nil, nil, err
 	}
 	svcLen := len(svcs)
+	var svc *api.ServiceEntry
 	switch svcLen {
 	case 0:
 		return nil, qm, nil
 	case 1:
-		return svcs[0], qm, nil
+		svc = svcs[0]
 	default:
-		return svcs[rand.Intn(svcLen)], qm, nil
+		svc = svcs[rand.Intn(svcLen)]
 	}
+
+	// Handle case where service address is blank, default to node address
+	if svc.Service.Address == "" {
+		svc.Service.Address = svc.Node.Address
+	}
+
+	return svc, qm, nil
 }
 
 // PickService will attempt to locate any registered service with a name + tag combination and return one at random from
@@ -302,6 +310,9 @@ OUTER:
 				continue OUTER
 			}
 
+		}
+		if se.Service.Address == "" {
+			se.Service.Address = se.Node.Address
 		}
 		retv = append(retv, se)
 	}


### PR DESCRIPTION
In other parts of the consul ecosystem, the node address is used when the service address is empty.  As an example:

https://github.com/hashicorp/consul-template/blob/c831cdcce03bfdcaf509590326eb2b465ebff1bf/dependency/health_service.go#L174

This would add some convenience to some of the places where the health endpoint is called and a service is returned, specifically the PickService* methods and ServiceByTags